### PR TITLE
fixing computeAggregateMetrics method

### DIFF
--- a/image-query-worker/projects/query-worker-project/query-controller-module/src/main/java/com/irisdemo/htap/workersrv/AccumulatedMetrics.java
+++ b/image-query-worker/projects/query-worker-project/query-controller-module/src/main/java/com/irisdemo/htap/workersrv/AccumulatedMetrics.java
@@ -90,15 +90,17 @@ public class AccumulatedMetrics
 			//if we are stopping the workers and no new records have been ingested.
 			if (deltaNumberOfRowsConsumed>0) 
 			{
+				double ellapsedTimeInSeconds = timeSpentOnWorkInMillis/1000d;
+
 				previousNumberOfRowsConsumed = numberOfRowsConsumed;
 				this.setRecordsConsumedPerSec(deltaNumberOfRowsConsumed);						
 				
 				this.setMBConsumedPerSec(MBConsumed - previousMBConsumed);
 				previousMBConsumed = MBConsumed;
 				
-				setAvgRecordsConsumedPerSec(numberOfRowsConsumed / timeSpentOnWorkInMillis);
+				setAvgRecordsConsumedPerSec(numberOfRowsConsumed / ellapsedTimeInSeconds);
 				
-				setAvgMBConsumedPerSec(MBConsumed / timeSpentOnWorkInMillis);
+				setAvgMBConsumedPerSec(MBConsumed / ellapsedTimeInSeconds);
 				
 				avgQueryAndConsumptionTimeInMillis = timeSpentOnWorkInMillis/numberOfRowsConsumed;
 			}


### PR DESCRIPTION
Fixing computeAggregateMetrics method to use seconds instead of millseconds when appropriate for realtime query metrics.